### PR TITLE
Rescue 'SocketError' when connection was interrupted

### DIFF
--- a/lib/tddium_client.rb
+++ b/lib/tddium_client.rb
@@ -13,6 +13,15 @@ module TddiumClient
   CLIENT_VERSION_HEADER = "X-Tddium-Client-Version"
   API_ERROR_TEXT = "An error occured: "
 
+  ERRORS = [ Errno::ECONNREFUSED,
+             Errno::ETIMEDOUT,
+             Timeout::Error,
+             OpenSSL::SSL::SSLError,
+             OpenSSL::SSL::Session::SessionError,
+             HTTPClient::TimeoutError,
+             HTTPClient::BadResponseError,
+             SocketError ]
+
   module Error
     class Base < RuntimeError; end
   end
@@ -129,10 +138,9 @@ module TddiumClient
       call_params = params.merge({:xid => xid})
 
       tries = 0
-
       begin
         http = @client.send(method, tddium_uri(api_path), :body => call_params.to_json, :header => headers)
-      rescue Errno::ECONNREFUSED, Errno::ETIMEDOUT, Timeout::Error, OpenSSL::SSL::SSLError, OpenSSL::SSL::Session::SessionError, HTTPClient::TimeoutError, HTTPClient::BadResponseError
+      rescue *ERRORS
         tries += 1
         delay = (tries>>1)*0.05*rand()
         Kernel.sleep(delay)

--- a/spec/tddium_client_spec.rb
+++ b/spec/tddium_client_spec.rb
@@ -204,7 +204,18 @@ describe "TddiumClient" do
       it "should print the explanation" do
         upgrade_required.message.should == "API Error: You need to upgrade"
       end
-    end    
+    end
+
+    it "should be in list of errors" do
+      TddiumClient::ERRORS.should be == [ Errno::ECONNREFUSED,
+                                          Errno::ETIMEDOUT,
+                                          Timeout::Error,
+                                          OpenSSL::SSL::SSLError,
+                                          OpenSSL::SSL::Session::SessionError,
+                                          HTTPClient::TimeoutError,
+                                          HTTPClient::BadResponseError,
+                                          SocketError ]
+    end
   end
 
   describe "InternalClient" do


### PR DESCRIPTION
First part of task
https://jira.slno.net/jira/browse/CICLI-64?filter=10311
Add SocketError to rescue interrupted connection